### PR TITLE
fix: Fix Intent & Entity name collisions with OC prefix

### DIFF
--- a/template/OCAgent.json
+++ b/template/OCAgent.json
@@ -1,6 +1,6 @@
 {
   "name": "💁 Agent",
-  "intentId": "Agent",
+  "intentId": "OCAgent",
   "langCode": "en-US",
   "slots": [
     {

--- a/template/OCNo.json
+++ b/template/OCNo.json
@@ -1,5 +1,5 @@
 {
-  "intentId": "No",
+  "intentId": "OCNo",
   "name": "👎 No",
   "slots": [
     {

--- a/template/OCSearch.json
+++ b/template/OCSearch.json
@@ -1,6 +1,6 @@
 {
   "content": {},
-  "intentId": "Search",
+  "intentId": "OCSearch",
   "name": "❓ Search",
   "nlu": {
     "lex-connect": {

--- a/template/OCYes.json
+++ b/template/OCYes.json
@@ -1,5 +1,5 @@
 {
-  "intentId": "Yes",
+  "intentId": "OCYes",
   "name": "👍 Yes",
   "slots": [
     {


### PR DESCRIPTION
Lex doesn't like it when your entity names and intent names are the same (case insensitive).  This prefixes the custom intents (not the built-in Cancel, Help, & Launch) with `OC` to help with the collisions.